### PR TITLE
Add option --stdin-filename to black invocation

### DIFF
--- a/Scripts/formatter.js
+++ b/Scripts/formatter.js
@@ -6,12 +6,9 @@ class Formatter {
     async getProcess(filename = null) {
         const executablePath = nova.path.expanduser(this.config.get("executablePath"));
         const commandArguments = this.config.get("commandArguments");
-
-        let defaultOptions = ["--quiet"];
-        if (filename !== null) {
-            defaultOptions = defaultOptions.concat(["--stdin-filename", filename]);
-        }
-        defaultOptions.push("-");
+        const defaultOptions = (filename)
+            ? ["--quiet", `--stdin-filename=${filename}`,  "-"]
+            : ["--quiet", "-"];
 
         if (!nova.fs.stat(executablePath)) {
             console.error(`Executable ${executablePath} does not exist`);
@@ -54,13 +51,9 @@ class Formatter {
             return;
         }
 
-        let filename;
-        if (editor.document.isUntitled) {
-            filename = null;
-        } else {
-            filename = nova.path.basename(editor.document.path);
-        }
-        let process = await this.getProcess(filename);
+        let process = await this.getProcess(
+            editor.document.path ? nova.path.basename(editor.document.path) : null
+        );
 
         if (!process) {
             if (reject) reject("no process");

--- a/Scripts/formatter.js
+++ b/Scripts/formatter.js
@@ -3,10 +3,15 @@ class Formatter {
         this.config = config;
     }
 
-    async getProcess() {
+    async getProcess(filename = null) {
         const executablePath = nova.path.expanduser(this.config.get("executablePath"));
         const commandArguments = this.config.get("commandArguments");
-        const defaultOptions = ["--quiet", "-"];
+
+        let defaultOptions = ["--quiet"];
+        if (filename !== null) {
+            defaultOptions = defaultOptions.concat(["--stdin-filename", filename]);
+        }
+        defaultOptions.push("-");
 
         if (!nova.fs.stat(executablePath)) {
             console.error(`Executable ${executablePath} does not exist`);
@@ -49,7 +54,13 @@ class Formatter {
             return;
         }
 
-        let process = await this.getProcess();
+        let filename;
+        if (editor.document.isUntitled) {
+            filename = null;
+        } else {
+            filename = nova.path.basename(editor.document.path);
+        }
+        let process = await this.getProcess(filename);
 
         if (!process) {
             if (reject) reject("no process");

--- a/extension.json
+++ b/extension.json
@@ -39,7 +39,7 @@
         {
             "key": "cc.aeron.nova-black.commandArguments",
             "title": "Command Arguments",
-            "description": "Additional arguments. The --quiet option always set.",
+            "description": "Additional arguments. The --quiet option is always set. The --stdin-filename is set conditionally.",
             "type": "string",
             "default": null
         },
@@ -61,7 +61,7 @@
         {
             "key": "cc.aeron.nova-black.commandArguments",
             "title": "Command Arguments",
-            "description": "Additional arguments. The --quiet option always set.",
+            "description": "Additional arguments. The --quiet option is always set. The --stdin-filename is set conditionally.",
             "type": "string"
         },
         {


### PR DESCRIPTION
Fixes https://github.com/Aeron/Black.novaextension/issues/4

Adds the `--stdin--filename` option to the black invocation, with the filename of the current buffer.

If the buffer is unsaved, don't add `--stdin--filename`.